### PR TITLE
ssl/tls1.c: If underlying stream returned EAGAIN, return SSL_EAGAIN.

### DIFF
--- a/ssl/ssl.h
+++ b/ssl/ssl.h
@@ -89,6 +89,7 @@ extern "C" {
 #define SSL_NOT_OK                              -1
 #define SSL_ERROR_DEAD                          -2
 #define SSL_CLOSE_NOTIFY                        -3
+#define SSL_EAGAIN                              -4
 #define SSL_ERROR_CONN_LOST                     -256
 #define SSL_ERROR_RECORD_OVERFLOW               -257
 #define SSL_ERROR_SOCK_SETUP_FAILURE            -258

--- a/ssl/tls1.c
+++ b/ssl/tls1.c
@@ -1313,7 +1313,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
 #else
         if (SOCKET_ERRNO() == EAGAIN || SOCKET_ERRNO() == EWOULDBLOCK)
 #endif
-            return 0;
+            return SSL_EAGAIN;
     }
 
     /* connection has gone, so die */


### PR DESCRIPTION
This helps better implement blocking vs non-blocking streams on top of
axTLS (e.g. in MicroPython). Value of SSL_EAGAIN is -4, care was taken
to make sure there's no TLS alert with value of 4 (because axTLS returns
negated alert values as errors).