### PR TITLE
Fix -fsanitize=undefined diagnostics

### DIFF
--- a/crypto/bigint.c
+++ b/crypto/bigint.c
@@ -628,7 +628,7 @@ bigint *bi_import(BI_CTX *ctx, const uint8_t *data, int size)
 
     for (i = size-1; i >= 0; i--)
     {
-        biR->comps[offset] += data[i] << (j*8);
+        biR->comps[offset] += (unsigned int)data[i] << (j*8);
 
         if (++j == COMP_BYTE_SIZE)
         {

--- a/crypto/crypto_misc.c
+++ b/crypto/crypto_misc.c
@@ -101,6 +101,12 @@ int get_file(const char *filename, uint8_t **buf)
  * - On Linux use /dev/urandom
  * - If none of these work then use a custom RNG.
  */
+#ifdef __GNUC__
+// The stack-entropy-grabbing memcpy() is tagged as an error by gcc
+// -fsanitize=undefined.
+__attribute__((no_sanitize_address))
+__attribute__((no_sanitize_undefined))
+#endif
 EXP_FUNC void STDCALL RNG_initialize()
 {
 #if !defined(WIN32) && defined(CONFIG_USE_DEV_URANDOM)

--- a/crypto/sha1.c
+++ b/crypto/sha1.c
@@ -121,7 +121,7 @@ static void SHA1ProcessMessageBlock(SHA1_CTX *ctx)
      */
     for  (t = 0; t < 16; t++)
     {
-        W[t] = ctx->Message_Block[t * 4] << 24;
+        W[t] = (uint32_t)ctx->Message_Block[t * 4] << 24;
         W[t] |= ctx->Message_Block[t * 4 + 1] << 16;
         W[t] |= ctx->Message_Block[t * 4 + 2] << 8;
         W[t] |= ctx->Message_Block[t * 4 + 3];


### PR DESCRIPTION
Fixes the following diagnostics:
```
bigint.c:631:39: runtime error: left shift of 162 by 24 places cannot be represented in type 'int'
sha1.c:124:42: runtime error: left shift of 152 by 24 places cannot be represented in type 'int'
```

Directs the sanitizer not to instrument the function where this diagnostic otherwise occurs:
```
crypto_misc.c:131:5: runtime error: load of address 0x7ffd83a8633c with insufficient space for an object of type 'unsigned char'
```
.. this function deliberately reads memory in a way that is undefined under the C standard, but is a semi-recognized technique to maybe supplement a CSPRNG entropy pool; blindly removing it is the riskier option, a la https://www.debian.org/security/2008/dsa-1571

These changes fix all the problems seen in axtls when running the testsuite of a popular embedded python implementation on a linux amd64 desktop with gcc 8.3.0 -fsanitize=undefined.

I don't know your branching policy in this repo, so feel free to close if this is not something you're interested in taking, or let me know which branch I should be working relative to so I can re-spin if necessary.